### PR TITLE
chore: use portable shebang in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 PROJECT_ROOT=$(pwd)


### PR DESCRIPTION
## Description
Replaced the hardcoded `#!/bin/bash` shebang with `#!/usr/bin/env bash` in `build.sh`


Using `/usr/bin/env bash` improves portability across different UNIX-like systems (such as NixOS, *BSD, or systems with custom prefixes), where `bash` may not be located at [/bin/bash](cci:7://file:///bin/bash:0:0-0:0).
