### PR TITLE
Jsilverhand48/bugfix

### DIFF
--- a/Nolvus.Browser/BrowserWindow.axaml.cs
+++ b/Nolvus.Browser/BrowserWindow.axaml.cs
@@ -248,10 +248,22 @@ namespace Nolvus.Browser
             var tcs = new TaskCompletionSource<string>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
 
+            var mainLoadTcs = new TaskCompletionSource<object?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
             void Requested(object? s, FileDownloadRequestEvent e)
             {
                 if (!string.IsNullOrWhiteSpace(e.DownloadUrl))
                     tcs.TrySetResult(e.DownloadUrl);
+            }
+
+            void LoadEnd(object? s, LoadEndEventArgs e)
+            {
+                if (!e.Frame.IsMain)
+                    return;
+
+                _cef.LoadEnd -= LoadEnd;
+                mainLoadTcs.TrySetResult(null);
             }
 
             handler.OnFileDownloadRequest += Requested;
@@ -259,23 +271,37 @@ namespace Nolvus.Browser
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
                 _cef.DownloadHandler = handler;
+                _cef.LoadEnd += LoadEnd;
                 NavigateInternal(link);
             });
 
-            string result;
             try
             {
-                result = await tcs.Task.ConfigureAwait(false);
+                if (ServiceSingleton.Settings.NexusAutoClick)
+                {
+                    await mainLoadTcs.Task.ConfigureAwait(false);
+
+                    await Dispatcher.UIThread.InvokeAsync(() =>
+                    {
+                        _cef.ExecuteJavaScript(ScriptManager.GetClickNexusSlowDownload());
+                    });
+                }
+
+                string result = await tcs.Task.ConfigureAwait(false);
+                return result;
             }
             finally
             {
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    try { _cef.LoadEnd -= LoadEnd; } catch { }
+                });
+
                 handler.OnFileDownloadRequest -= Requested;
 
                 await Dispatcher.UIThread.InvokeAsync(CloseBrowser);
                 await WaitForClosedAsync().ConfigureAwait(false);
             }
-
-            return result;
         }
 
         private void DisposeCefIfNeeded()

--- a/Nolvus.Browser/Core/ScriptManager.cs
+++ b/Nolvus.Browser/Core/ScriptManager.cs
@@ -9,6 +9,7 @@ namespace Nolvus.Browser.Core
     public static class ScriptManager
     {
         public static string ScrollToButton          = "(function () { var el = document.getElementById('slowDownloadButton'); if (el) { el.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' }); } })();";
+        public static string ClickNexusSlowDownload  = "(function(){ var attempts=0; var iv=setInterval(function(){ var host=document.querySelector('mod-file-download'); if(host && host.shadowRoot){ var btn=host.shadowRoot.querySelector('button'); if(btn){ clearInterval(iv); var delay=1000+Math.floor(Math.random()*2000); setTimeout(function(){ btn.click(); },delay); return; } } if(++attempts>=30) clearInterval(iv); },500); })();";
         public static string IsDownloadAvailable     = "(function () { let val = 0; if (document.getElementById('slowDownloadButton') != null) { val = 1 }; return val; })();";
         public static string IsFileDeleted           = "(function() { let val = 0; if (document.getElementsByClassName('info-content') && document.getElementsByClassName('info-content')[0].innerHTML.indexOf('This file has been removed') !== -1) { val = 1 }; return val; })();";
         public static string IsModNotFound           = "(function() { let val = 0; if (document.getElementsByClassName('info-content') && document.getElementsByClassName('info-content')[0].innerHTML.indexOf('Not found') !== -1) { val = 1 }; return val; })();";
@@ -42,8 +43,13 @@ namespace Nolvus.Browser.Core
         }
 
         public static string GetNexusManualDownloadInit()
-        {            
+        {
             return ScriptManager.NexusManualDownloadInit;
+        }
+
+        public static string GetClickNexusSlowDownload()
+        {
+            return ScriptManager.ClickNexusSlowDownload;
         }
 
         public static string GetNexusManualDownload()

--- a/Nolvus.Core/Interfaces/ISettingsService.cs
+++ b/Nolvus.Core/Interfaces/ISettingsService.cs
@@ -20,6 +20,7 @@ namespace Nolvus.Core.Interfaces
         int ErrorsThreshold { get; }
         string BrowserLogSeverity { get; }
         bool DevDebug { get; }
+        bool NexusAutoClick { get; set; }
         FileIniDataParser GetIniParser();
     }
 }

--- a/Nolvus.Core/Utils/PosixWait.cs
+++ b/Nolvus.Core/Utils/PosixWait.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Nolvus.Core.Utils
+{
+    /// <summary>
+    /// Direct waitpid() via P/Invoke for Linux process reaping.
+    ///
+    /// WaitForExitAsync() and WaitForExit() do not work reliably on this system —
+    /// they hang indefinitely, leaving child processes zombified.
+    /// Calling waitpid() directly is the only mechanism proven to reap children here.
+    ///
+    /// Always call from a dedicated OS thread (not a thread-pool thread) so the
+    /// thread pool remains free to service async I/O callbacks.
+    /// </summary>
+    public static class PosixWait
+    {
+        [DllImport("libc", SetLastError = true)]
+        private static extern int waitpid(int pid, out int status, int options);
+
+        public static int WaitForExitBlocking(int pid)
+        {
+            while (true)
+            {
+                int rc = waitpid(pid, out int status, 0);
+
+                if (rc == pid)
+                    return DecodeExitCode(status);
+
+                if (rc == -1)
+                {
+                    int err = Marshal.GetLastWin32Error();
+                    const int ECHILD = 10; // already reaped by another thread
+                    if (err == ECHILD) return 0;
+                    throw new Exception($"waitpid({pid}) failed errno={err}");
+                }
+            }
+        }
+
+        private static int DecodeExitCode(int status)
+        {
+            if ((status & 0x7F) == 0)
+                return (status >> 8) & 0xFF;   // normal exit
+            return 128 + (status & 0x7F);       // killed by signal
+        }
+    }
+}

--- a/Nolvus.Dashboard/DashboardWindow.axaml.cs
+++ b/Nolvus.Dashboard/DashboardWindow.axaml.cs
@@ -22,6 +22,7 @@ namespace Nolvus.Dashboard;
 public partial class DashboardWindow : Window, IDashboard
 {
     private DashboardFrame LoadedFrame;
+    internal Type? SettingsReturnFrameType;
 
     #region Events
 
@@ -554,12 +555,13 @@ public partial class DashboardWindow : Window, IDashboard
     }
 
     private void TitleBarControl_OnSettingsClicked(object? sender, EventArgs e)
-    {   
+    {
         var owner = TopLevel.GetTopLevel(this) as Window;
-        if (!ServiceSingleton.Packages.Processing) 
+        if (!ServiceSingleton.Packages.Processing)
         {
-            if (TitleBarControl.SettingsEnabled) 
+            if (TitleBarControl.SettingsEnabled)
             {
+                SettingsReturnFrameType = LoadedFrame?.GetType();
                 ServiceSingleton.Dashboard.LoadFrame<GlobalSettingsFrame>();
             }
             else

--- a/Nolvus.Dashboard/DashboardWindow.axaml.cs
+++ b/Nolvus.Dashboard/DashboardWindow.axaml.cs
@@ -22,7 +22,6 @@ namespace Nolvus.Dashboard;
 public partial class DashboardWindow : Window, IDashboard
 {
     private DashboardFrame LoadedFrame;
-    internal Type? SettingsReturnFrameType;
 
     #region Events
 
@@ -555,13 +554,12 @@ public partial class DashboardWindow : Window, IDashboard
     }
 
     private void TitleBarControl_OnSettingsClicked(object? sender, EventArgs e)
-    {
+    {   
         var owner = TopLevel.GetTopLevel(this) as Window;
-        if (!ServiceSingleton.Packages.Processing)
+        if (!ServiceSingleton.Packages.Processing) 
         {
-            if (TitleBarControl.SettingsEnabled)
+            if (TitleBarControl.SettingsEnabled) 
             {
-                SettingsReturnFrameType = LoadedFrame?.GetType();
                 ServiceSingleton.Dashboard.LoadFrame<GlobalSettingsFrame>();
             }
             else

--- a/Nolvus.Dashboard/Frames/Settings/GlobalSettingsFrame.axaml
+++ b/Nolvus.Dashboard/Frames/Settings/GlobalSettingsFrame.axaml
@@ -15,7 +15,7 @@
 
             <!-- CONTENT AREA -->
             <Grid Grid.Row="1"
-                  ColumnDefinitions="520,24,235,*">
+                  ColumnDefinitions="520,24,235,24,235,*">
 
                 <!-- MEGA SETTINGS PANEL -->
                 <Border x:Name="GrpBxMega"
@@ -161,6 +161,39 @@
                                   Width="189"
                                   HorizontalAlignment="Left"
                                   SelectionChanged="OnProcessorCountChanged"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- BROWSER SETTINGS PANEL -->
+                <Border x:Name="GrpBxBrowser"
+                        Grid.Column="4"
+                        Background="#363636"
+                        BorderBrush="#444"
+                        BorderThickness="1"
+                        CornerRadius="4"
+                        Padding="16"
+                        Width="235"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Top">
+
+                    <StackPanel Spacing="12">
+                        <TextBlock Text="Browser"
+                                   Foreground="White"
+                                   FontSize="16"
+                                   FontWeight="SemiBold"/>
+
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="12"
+                                    VerticalAlignment="Center">
+                            <TextBlock Text="Auto Click Slow Download"
+                                       Foreground="#CCCCCC"
+                                       VerticalAlignment="Center"
+                                       TextWrapping="Wrap"
+                                       Width="115"/>
+                            <ToggleSwitch x:Name="TglBtnAutoClick"
+                                          IsCheckedChanged="TglBtnAutoClick_Changed"
+                                          VerticalAlignment="Center"/>
+                        </StackPanel>
                     </StackPanel>
                 </Border>
 

--- a/Nolvus.Dashboard/Frames/Settings/GlobalSettingsFrame.axaml.cs
+++ b/Nolvus.Dashboard/Frames/Settings/GlobalSettingsFrame.axaml.cs
@@ -75,18 +75,7 @@ namespace Nolvus.Dashboard.Frames.Settings
 
         private async void BtnBack_Click(object? sender, RoutedEventArgs e)
         {
-            var window = TopLevel.GetTopLevel(this) as DashboardWindow;
-            var returnType = window?.SettingsReturnFrameType;
-
-            if (returnType != null && typeof(DashboardFrame).IsAssignableFrom(returnType))
-            {
-                var method = typeof(IDashboard).GetMethod("LoadFrameAsync")!.MakeGenericMethod(returnType);
-                await (Task)method.Invoke(ServiceSingleton.Dashboard, new object?[] { null })!;
-            }
-            else
-            {
-                await ServiceSingleton.Dashboard.LoadFrameAsync<StartFrame>();
-            }
+            await ServiceSingleton.Dashboard.LoadFrameAsync<StartFrame>();
         }
 
         private async void BtnSaveMegaInfo_Click(object? sender, RoutedEventArgs e)

--- a/Nolvus.Dashboard/Frames/Settings/GlobalSettingsFrame.axaml.cs
+++ b/Nolvus.Dashboard/Frames/Settings/GlobalSettingsFrame.axaml.cs
@@ -75,7 +75,18 @@ namespace Nolvus.Dashboard.Frames.Settings
 
         private async void BtnBack_Click(object? sender, RoutedEventArgs e)
         {
-            await ServiceSingleton.Dashboard.LoadFrameAsync<StartFrame>();
+            var window = TopLevel.GetTopLevel(this) as DashboardWindow;
+            var returnType = window?.SettingsReturnFrameType;
+
+            if (returnType != null && typeof(DashboardFrame).IsAssignableFrom(returnType))
+            {
+                var method = typeof(IDashboard).GetMethod("LoadFrameAsync")!.MakeGenericMethod(returnType);
+                await (Task)method.Invoke(ServiceSingleton.Dashboard, new object?[] { null })!;
+            }
+            else
+            {
+                await ServiceSingleton.Dashboard.LoadFrameAsync<StartFrame>();
+            }
         }
 
         private async void BtnSaveMegaInfo_Click(object? sender, RoutedEventArgs e)

--- a/Nolvus.Dashboard/Frames/Settings/GlobalSettingsFrame.axaml.cs
+++ b/Nolvus.Dashboard/Frames/Settings/GlobalSettingsFrame.axaml.cs
@@ -40,6 +40,8 @@ namespace Nolvus.Dashboard.Frames.Settings
 
                 DrpDwnLstProcessCount.ItemsSource = GetProcessorCores();
                 DrpDwnLstProcessCount.SelectedIndex = CoreIndex(GetProcessorCores());
+
+                TglBtnAutoClick.IsChecked = ServiceSingleton.Settings.NexusAutoClick;
             }
             catch (Exception ex)
             {
@@ -163,6 +165,11 @@ namespace Nolvus.Dashboard.Frames.Settings
         private void OnProcessorCountChanged(object? sender, RoutedEventArgs e)
         {
             ServiceSingleton.Settings.ProcessCount = (int)DrpDwnLstProcessCount.SelectedItem!;
+        }
+
+        private void TglBtnAutoClick_Changed(object? sender, RoutedEventArgs e)
+        {
+            ServiceSingleton.Settings.NexusAutoClick = TglBtnAutoClick.IsChecked == true;
         }
     }
 }

--- a/Nolvus.Package/Mods/BsaUnPacking.cs
+++ b/Nolvus.Package/Mods/BsaUnPacking.cs
@@ -2,10 +2,9 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Nolvus.Core.Services;
-using Nolvus.Core.Interfaces;
-using Nolvus.Package.Services;
 using System.Diagnostics;
+using Nolvus.Core.Services;
+using Nolvus.Core.Utils;
 
 namespace Nolvus.Package.Mods
 {
@@ -38,72 +37,61 @@ namespace Nolvus.Package.Mods
 
         public async Task UnPack(string extractDir)
         {
-            var Tsk = Task.Run(() =>
+            var bsaFile = GetBsaToUnpack(extractDir);
+            var bsArchPath = Path.Combine(ServiceSingleton.Folders.LibDirectory, "BSArch");
+
+            if (!File.Exists(bsArchPath))
+                throw new FileNotFoundException($"BSArch not found: {bsArchPath}", bsArchPath);
+
+            if (bsaFile == null)
+                throw new Exception("Failed to unpack file : " + FileName + "==> File not found");
+
+            var psi = new ProcessStartInfo
             {
-                var bsaFile = GetBsaToUnpack(extractDir);
-                var BSArch = Path.Combine(ServiceSingleton.Folders.LibDirectory, "BSArch");
+                FileName = bsArchPath,
+                WorkingDirectory = ServiceSingleton.Folders.LibDirectory,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
 
-                if (!File.Exists(BSArch))
-                    throw new FileNotFoundException($"BSArch not found: {BSArch}", BSArch);
+            psi.ArgumentList.Add("unpack");
+            psi.ArgumentList.Add(bsaFile.FullName);
+            psi.ArgumentList.Add(bsaFile.DirectoryName);
 
-                if (bsaFile != null)
-                {
-                    var psi = new ProcessStartInfo
-                    {
-                        FileName = BSArch,
-                        WorkingDirectory = ServiceSingleton.Folders.LibDirectory,
-                        UseShellExecute = false,
-                        CreateNoWindow = true,
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true
-                    };
+            ServiceSingleton.Logger.Log($"Unpacking command line : \"{bsArchPath}\" unpack \"{bsaFile.FullName}\" \"{bsaFile.DirectoryName}\"");
 
-                    psi.ArgumentList.Add("unpack");
-                    psi.ArgumentList.Add(bsaFile.FullName);
-                    psi.ArgumentList.Add(bsaFile.DirectoryName);
+            using var unpack = new Process { StartInfo = psi };
+            unpack.Start();
 
-                    ServiceSingleton.Logger.Log($"Unpacking command line : \"{BSArch}\" unpack \"{bsaFile.FullName}\" \"{bsaFile.DirectoryName}\"");
+            // 1. Drain both pipes concurrently before waiting for exit.
+            //    Sequential reads deadlock if the process fills one pipe while we block on the other.
+            var stdoutTask = unpack.StandardOutput.ReadToEndAsync();
+            var stderrTask = unpack.StandardError.ReadToEndAsync();
 
-                    var unpack = new Process { StartInfo = psi };
-                    List<string> output = new();
+            // 2. Wait for process exit via direct waitpid() — WaitForExitAsync hangs on this system.
+            var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            int pid = unpack.Id;
+            new Thread(() =>
+            {
+                try { tcs.TrySetResult(PosixWait.WaitForExitBlocking(pid)); }
+                catch (Exception ex) { tcs.TrySetException(ex); }
+            }) { IsBackground = true, Name = $"bsarch-wait-{pid}" }.Start();
 
-                    unpack.OutputDataReceived += (_, e) =>
-                    {
-                        if (!string.IsNullOrWhiteSpace(e.Data))
-                        {
-                            output.Add(e.Data);
-                        }
-                    };
+            int exitCode = await tcs.Task;
 
-                    unpack.ErrorDataReceived += (_, e) =>
-                    {
-                        if (!string.IsNullOrWhiteSpace(e.Data))
-                        {
-                            output.Add(e.Data);
-                        }
-                    };
+            // 3. Collect any remaining buffered output after the process has exited.
+            string output = await stdoutTask + await stderrTask;
 
-                    unpack.Start();
-                    unpack.BeginOutputReadLine();
-                    unpack.BeginErrorReadLine();
-                    unpack.WaitForExit();
-
-                    if (unpack.ExitCode == 0)
-                    {
-                        File.Delete(bsaFile.FullName);
-                    }
-                    else
-                    {
-                        throw new Exception("Failed to unpack file : " + FileName + "==>" + string.Join(Environment.NewLine, output.ToArray()));
-                    }
-                }
-                else
-                {
-                    throw new Exception("Failed to unpack file : " + FileName + "==> File not found");
-                }
-            });
-
-            await Tsk;
+            if (exitCode == 0)
+            {
+                File.Delete(bsaFile.FullName);
+            }
+            else
+            {
+                throw new Exception("Failed to unpack file : " + FileName + "==>" + output);
+            }
         }
     }
 }

--- a/Nolvus.Package/Mods/Reshade.cs
+++ b/Nolvus.Package/Mods/Reshade.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Diagnostics;
 using Nolvus.Core.Services;
 using Nolvus.Core.Interfaces;
+using Nolvus.Core.Utils;
 
 
 namespace Nolvus.Package.Mods
@@ -140,65 +141,65 @@ WindowRounding=0.000000";
         
         protected override async Task DoExtract()
         {
-            await Task.Run(() =>
+            try
             {
-                try
+                ServiceSingleton.Logger.Log("Extracting reshade binaries");
+
+                ServiceSingleton.Files.RemoveDirectory(
+                    Path.Combine(ServiceSingleton.Folders.ExtractDirectory, Name),
+                    true);
+
+                string sevenZip = Path.Combine(ServiceSingleton.Folders.LibDirectory, "7z");
+                string zipFile = this.Files.First().LocationFileName;
+                string outDir = Path.Combine(ServiceSingleton.Folders.ExtractDirectory, Name);
+
+                var psi = new ProcessStartInfo
                 {
-                    ServiceSingleton.Logger.Log("Extracting reshade binaries");
+                    FileName = sevenZip,
+                    WorkingDirectory = ServiceSingleton.Folders.DownloadDirectory,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                };
 
-                    ServiceSingleton.Files.RemoveDirectory(
-                        Path.Combine(ServiceSingleton.Folders.ExtractDirectory, Name),
-                        true);
+                psi.ArgumentList.Add("x");
+                psi.ArgumentList.Add("-bsp1");
+                psi.ArgumentList.Add("-y");
+                psi.ArgumentList.Add(zipFile);
+                psi.ArgumentList.Add($"-o{outDir}");
+                psi.ArgumentList.Add("-mmt=off");
 
-                    string sevenZip = Path.Combine(ServiceSingleton.Folders.LibDirectory, "7z");
+                using var proc = new Process { StartInfo = psi };
+                proc.Start();
 
-                    string zipFile = this.Files.First().LocationFileName;
-                    string outDir = Path.Combine(ServiceSingleton.Folders.ExtractDirectory, Name);
+                // 1. Drain both pipes concurrently before waiting — prevents buffer deadlock.
+                var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+                var stderrTask = proc.StandardError.ReadToEndAsync();
 
-                    var psi = new ProcessStartInfo
-                    {
-                        FileName = sevenZip,
-                        Arguments = $"x -bsp1 -y \"{zipFile}\" -o\"{outDir}\" -mmt=off",
-                        WorkingDirectory = ServiceSingleton.Folders.DownloadDirectory,
-                        UseShellExecute = false,
-                        CreateNoWindow = true,
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true
-                    };
-
-                    var proc = new Process { StartInfo = psi };
-                    var output = new List<string>();
-
-                    proc.OutputDataReceived += (s, e) =>
-                    {
-                        if (!string.IsNullOrEmpty(e.Data))
-                            output.Add(e.Data);
-                    };
-
-                    proc.ErrorDataReceived += (s, e) =>
-                    {
-                        if (!string.IsNullOrEmpty(e.Data))
-                            output.Add(e.Data);
-                    };
-
-                    proc.Start();
-                    proc.BeginOutputReadLine();
-                    proc.BeginErrorReadLine();
-                    proc.WaitForExit();
-
-                    if (proc.ExitCode != 0)
-                    {
-                        throw new Exception("Error during reshade extraction:\n" +
-                                            string.Join("\n", output));
-                    }
-                }
-                catch (Exception ex)
+                // 2. Reap via waitpid() on a dedicated thread — WaitForExitAsync hangs on this system.
+                var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+                int pid = proc.Id;
+                new Thread(() =>
                 {
-                    ServiceSingleton.Logger.Log(
-                        $"Error during reshade binaries extraction: {ex.Message}");
-                    throw;
-                }
-            });
+                    try { tcs.TrySetResult(PosixWait.WaitForExitBlocking(pid)); }
+                    catch (Exception ex) { tcs.TrySetException(ex); }
+                }) { IsBackground = true, Name = $"7z-reshade-wait-{pid}" }.Start();
+
+                int exitCode = await tcs.Task;
+
+                // 3. Collect remaining output after process has exited.
+                string output = await stderrTask;
+                await stdoutTask;
+
+                if (exitCode != 0)
+                    throw new Exception("Error during reshade extraction:\n" + output);
+            }
+            catch (Exception ex)
+            {
+                ServiceSingleton.Logger.Log($"Error during reshade binaries extraction: {ex.Message}");
+                throw;
+            }
         }
 
         protected override async Task PrepareDirectory()

--- a/Nolvus.Services/Files/Extractor/FileExtractor.cs
+++ b/Nolvus.Services/Files/Extractor/FileExtractor.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using Nolvus.Core.Events;
 using Nolvus.Core.Services;
+using Nolvus.Core.Utils;
 
 namespace Nolvus.Services.Files.Extractor
 {
@@ -31,124 +31,84 @@ namespace Nolvus.Services.Files.Extractor
             ServiceSingleton.Logger.Log("File to extract: " + File);
             ServiceSingleton.Logger.Log("Outpath path: " + Output);
 
-            await Task.Run(() =>
+            FileName = Path.GetFileName(File);
+
+            try
             {
-                FileName = Path.GetFileName(File);
+                if (OnProgress != null)
+                    ExtractProgressChanged += OnProgress;
 
-                try
+                if (!Directory.Exists(Output))
+                    Directory.CreateDirectory(Output);
+
+                var sevenZipPath = Path.Combine(ServiceSingleton.Folders.LibDirectory, "7z");
+
+                var psi = new ProcessStartInfo
                 {
-                    if (OnProgress != null)
-                        ExtractProgressChanged += OnProgress;
+                    FileName = sevenZipPath,
+                    Arguments = $"x -bsp1 -y \"{File}\" -o\"{Output}\" -mmt=off",
+                    WorkingDirectory = ServiceSingleton.Folders.LibDirectory,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                };
 
-                    if (!Directory.Exists(Output))
-                        Directory.CreateDirectory(Output);
+                using var proc = new Process { StartInfo = psi };
+                proc.Start();
 
-                    var sevenZipPath = Path.Combine(ServiceSingleton.Folders.LibDirectory, "7z");
-
-                    var psi = new ProcessStartInfo
-                    {
-                        FileName = sevenZipPath,
-                        Arguments = $"x -bsp1 -y \"{File}\" -o\"{Output}\" -mmt=off",
-                        WorkingDirectory = ServiceSingleton.Folders.LibDirectory,
-                        UseShellExecute = false,
-                        CreateNoWindow = true,
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true
-                    };
-
-                    var proc = new Process { StartInfo = psi };
-                    List<string> errorOutput = new();
-
-                    proc.OutputDataReceived += (s, e) =>
-                    {
-                        if (e.Data != null && e.Data.Length >= 4 && e.Data[3] == '%')
-                        {
-                            if (int.TryParse(e.Data.Substring(0, 3), out var pct))
-                                TriggerProgressEvent(pct, FileName);
-                        }
-                    };
-
-                    proc.ErrorDataReceived += (s, e) =>
-                    {
-                        if (e.Data != null)
-                            errorOutput.Add(e.Data);
-                    };
-
-                    proc.Start();
-                    proc.BeginOutputReadLine();
-                    proc.BeginErrorReadLine();
-
-                    int exitCode = PosixWait.WaitForExitBlocking(proc.Id);
-                    
-                    try 
-                    {
-                        proc.Refresh();
-                    } 
-                    catch { }
-
-                    if (exitCode != 0)
-                        throw new Exception($"Error during File extraction {FileName} (exit code {exitCode}): {string.Join(" ", errorOutput)}");
-
-                    TriggerProgressEvent(100, FileName);
-                }
-                catch (Exception ex)
+                // 1. Start draining stdout line-by-line for progress reporting.
+                //    Must start BEFORE waiting so the pipe never fills and blocks 7z.
+                var progressTask = Task.Run(async () =>
                 {
-                    ServiceSingleton.Logger.Log(ex.Message);
-                    throw;
-                }
-                finally
-                {
-                    if (OnProgress != null)
+                    string line;
+                    while ((line = await proc.StandardOutput.ReadLineAsync()) != null)
                     {
-                        try 
-                        {
-                            ExtractProgressChanged -= OnProgress;
-                        } 
-                        catch { }
+                        if (line.Length >= 4 && line[3] == '%' && int.TryParse(line[..3], out var pct))
+                            TriggerProgressEvent(pct, FileName);
                     }
-                }
-            });
-        }
+                });
 
-        private static class PosixWait
-        {
-            [DllImport("libc", SetLastError = true)]
-            private static extern int waitpid(int pid, out int status, int options);
+                // 2. Start draining stderr concurrently for the same reason.
+                var stderrTask = proc.StandardError.ReadToEndAsync();
 
-            // Wait until the given PID is reaped. No timeout.
-            public static int WaitForExitBlocking(int pid)
-            {
-                while (true)
+                // 3. Wait for the process to exit on a dedicated OS thread.
+                //    WaitForExitAsync() hangs indefinitely on this system — PosixWait
+                //    calls waitpid() directly which is the only reliable mechanism here.
+                var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+                int pid = proc.Id;
+                new Thread(() =>
                 {
-                    int rc = waitpid(pid, out int status, 0);
+                    try { tcs.TrySetResult(PosixWait.WaitForExitBlocking(pid)); }
+                    catch (Exception ex) { tcs.TrySetException(ex); }
+                }) { IsBackground = true, Name = $"7z-wait-{pid}" }.Start();
 
-                    if (rc == pid)
-                        return DecodeExitCode(status);
+                int exitCode = await tcs.Task;
 
-                    if (rc == -1)
-                    {
-                        int err = Marshal.GetLastWin32Error();
+                // 4. Let the stream readers finish consuming any remaining buffered data.
+                string errorOutput = await stderrTask;
+                await progressTask;
 
-                        // If errno == ECHILD, someone else already reaped it.
-                        // Treat as success; extraction already finished.
-                        const int ECHILD = 10;
-                        if (err == ECHILD)
-                            return 0;
+                if (exitCode != 0)
+                    throw new Exception($"Error during File extraction {FileName} (exit code {exitCode}): {errorOutput}");
 
-                        throw new Exception($"waitpid({pid}) failed errno={err}");
-                    }
-                }
+                TriggerProgressEvent(100, FileName);
             }
-
-            private static int DecodeExitCode(int status)
+            catch (Exception ex)
             {
-                // Normal exit: low 7 bits are zero, exit code is high byte.
-                if ((status & 0x7F) == 0)
-                    return (status >> 8) & 0xFF;
-
-                // Signaled: return 128+signal (bash convention)
-                int sig = status & 0x7F;
-                return 128 + sig;
+                ServiceSingleton.Logger.Log(ex.Message);
+                throw;
+            }
+            finally
+            {
+                if (OnProgress != null)
+                {
+                    try
+                    {
+                        ExtractProgressChanged -= OnProgress;
+                    }
+                    catch { }
+                }
             }
         }
     }

--- a/Nolvus.Services/Settings/SettingsService.cs
+++ b/Nolvus.Services/Settings/SettingsService.cs
@@ -22,6 +22,7 @@ namespace Nolvus.Services.Settings
         public const string Interval = "RefreshInterval";
         public const string Browser = "Browser";
         public const string LogSeverity = "LogSeverity";
+        public const string AutoClick = "AutoClick";
         public const string DevSection = "Dev";
         public const string DebugEnabled = "Debug";
 
@@ -202,6 +203,25 @@ namespace Nolvus.Services.Settings
                 {
                     return false;
                 }
+            }
+        }
+
+        public bool NexusAutoClick
+        {
+            get
+            {
+                try
+                {
+                    return System.Convert.ToBoolean(GetIniValue(Browser, AutoClick));
+                }
+                catch
+                {
+                    return true;
+                }
+            }
+            set
+            {
+                StoreIniValue(Browser, AutoClick, value.ToString());
             }
         }
     }

--- a/Nolvus.StockGame/Patcher/PatchManager.cs
+++ b/Nolvus.StockGame/Patcher/PatchManager.cs
@@ -11,7 +11,6 @@ using Nolvus.Core.Utils;
 using Nolvus.Core.Enums;
 using Nolvus.StockGame.Core;
 using Nolvus.StockGame.Meta;
-using Nolvus.Core.Utils;
 
 namespace Nolvus.StockGame.Patcher
 {
@@ -202,18 +201,32 @@ namespace Nolvus.StockGame.Patcher
 
                 process.Start();
 
-                string stdout = await process.StandardOutput.ReadToEndAsync();
-                string stderr = await process.StandardError.ReadToEndAsync();
+                // 1. Drain both pipes concurrently before waiting — prevents buffer deadlock.
+                var stdoutTask = process.StandardOutput.ReadToEndAsync();
+                var stderrTask = process.StandardError.ReadToEndAsync();
 
-                await process.WaitForExitAsync();
+                // 2. Reap via waitpid() on a dedicated thread — WaitForExitAsync hangs on this system.
+                var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+                int pid = process.Id;
+                new Thread(() =>
+                {
+                    try { tcs.TrySetResult(PosixWait.WaitForExitBlocking(pid)); }
+                    catch (Exception ex) { tcs.TrySetException(ex); }
+                }) { IsBackground = true, Name = $"xdelta3-dopatch-wait-{pid}" }.Start();
 
-                ServiceSingleton.Logger.Log($"Exit code: {process.ExitCode}");
+                int exitCode = await tcs.Task;
+
+                // 3. Collect remaining output after process has exited.
+                string stdout = await stdoutTask;
+                string stderr = await stderrTask;
+
+                ServiceSingleton.Logger.Log($"Exit code: {exitCode}");
                 if (!string.IsNullOrWhiteSpace(stdout))
                     ServiceSingleton.Logger.Log($"stdout: {stdout}");
                 if (!string.IsNullOrWhiteSpace(stderr))
                     ServiceSingleton.Logger.Log($"stderr: {stderr}");
 
-                if (process.ExitCode != 0)
+                if (exitCode != 0)
                 {
                     throw new GameFilePatchingException(
                         $"Failed to patch game file : {Instruction.DestFile.Name}",
@@ -254,52 +267,78 @@ namespace Nolvus.StockGame.Patcher
 
         public async Task PatchFile(string sourceFile, string destinationFile, string patchFile)
         {
-            var task = Task.Run(() =>
+            try
             {
+                var workingDirectory = new FileInfo(destinationFile).DirectoryName ?? ".";
+                var xdeltaPath = Path.Combine(ServiceSingleton.Folders.LibDirectory, "xdelta3");
+
+                var psi = new ProcessStartInfo
+                {
+                    FileName = xdeltaPath,
+                    WorkingDirectory = workingDirectory,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                psi.ArgumentList.Add("-d");
+                psi.ArgumentList.Add("-f");
+                psi.ArgumentList.Add("-s");
+                psi.ArgumentList.Add(sourceFile);
+                psi.ArgumentList.Add(patchFile);
+                psi.ArgumentList.Add(destinationFile);
+
+                using var proc = new Process { StartInfo = psi };
+                proc.Start();
+
+                // 1. Drain both pipes concurrently before waiting — prevents buffer deadlock.
+                var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+                var stderrTask = proc.StandardError.ReadToEndAsync();
+
+                ServiceSingleton.Logger.Log("Patching await start");
+
+                // 2. Reap via waitpid() on a dedicated thread — WaitForExitAsync hangs on this system.
+                var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+                int pid = proc.Id;
+                new Thread(() =>
+                {
+                    try { tcs.TrySetResult(PosixWait.WaitForExitBlocking(pid)); }
+                    catch (Exception ex) { tcs.TrySetException(ex); }
+                }) { IsBackground = true, Name = $"xdelta3-wait-{pid}" }.Start();
+
+                using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromMinutes(5));
+                cts.Token.Register(() => tcs.TrySetCanceled());
+
+                int exitCode;
                 try
                 {
-                    var workingDirectory = new FileInfo(destinationFile).DirectoryName ?? ".";
-                    
-                    var xdeltaPath = Path.Combine(ServiceSingleton.Folders.LibDirectory, "xdelta3");
-                    var psi = new ProcessStartInfo
-                    {
-                        FileName = xdeltaPath,
-                        Arguments = $"-d -f -s \"{sourceFile}\" \"{patchFile}\" \"{destinationFile}\"",
-                        WorkingDirectory = workingDirectory,
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true,
-                        UseShellExecute = false,
-                        CreateNoWindow = true
-                    };
-
-                    using var proc = new Process { StartInfo = psi };
-
-                    List<string> output = new();
-                    proc.OutputDataReceived += (_, e) => { if (e.Data != null) output.Add(e.Data); };
-                    proc.ErrorDataReceived += (_, e) => { if (e.Data != null) output.Add(e.Data); };
-
-                    proc.Start();
-                    proc.BeginOutputReadLine();
-                    proc.BeginErrorReadLine();
-                    proc.WaitForExit();
-
-                    if (proc.ExitCode != 0)
-                    {
-                        throw new Exception(
-                            $"xdelta3 failed (exit {proc.ExitCode})\n{string.Join(Environment.NewLine, output)}");
-                    }
-
-                    ServiceSingleton.Logger.Log(
-                        $"Patched {Path.GetFileName(destinationFile)} successfully (exit {proc.ExitCode})");
+                    exitCode = await tcs.Task;
                 }
-                catch (Exception ex)
+                catch (TaskCanceledException)
                 {
-                    ServiceSingleton.Logger.Log($"PatchFile error: {ex.Message}");
-                    throw;
+                    // Kill() is wrapped in try/catch — the process may have exited between the
+                    // timeout firing and Kill() being called (race condition).
+                    try { proc.Kill(entireProcessTree: true); } catch { }
+                    throw new Exception($"xdelta3 timed out after 5 minutes patching {Path.GetFileName(destinationFile)}");
                 }
-            });
 
-            await task;
+                ServiceSingleton.Logger.Log("Patching await end");
+
+                // 3. Collect remaining output after process has exited.
+                string stderr = await stderrTask;
+                await stdoutTask;
+
+                if (exitCode != 0)
+                    throw new Exception($"xdelta3 failed (exit {exitCode})\n{stderr}");
+
+                ServiceSingleton.Logger.Log($"Patched {Path.GetFileName(destinationFile)} successfully (exit {exitCode})");
+            }
+            catch (Exception ex)
+            {
+                ServiceSingleton.Logger.Log($"PatchFile error: {ex.Message}");
+                throw;
+            }
         }
 
         private void DeleteFile(PatchingInstruction Instruction, string DestDir)


### PR DESCRIPTION
- Fixed a bug where 7z/xdelta3/bsarchive processes zombify during browser-assisted downloads due to possible CEF SIGCHLD interference. 
- Fixed a bug where navigating to the settings page and back out causes the entire app to reload and check for updates unnecessarily. 