### PR TITLE
fix: use a working way of awaiting extraction finish

### DIFF
--- a/Nolvus.Services/Files/Extractor/FileExtractor.cs
+++ b/Nolvus.Services/Files/Extractor/FileExtractor.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using Nolvus.Core.Events;
 using Nolvus.Core.Services;
 
@@ -56,7 +55,7 @@ namespace Nolvus.Services.Files.Extractor
                         RedirectStandardError = true
                     };
 
-                    var proc = new Process { StartInfo = psi };
+                    using var proc = new Process { StartInfo = psi };
                     List<string> errorOutput = new();
 
                     proc.OutputDataReceived += (s, e) =>
@@ -78,13 +77,9 @@ namespace Nolvus.Services.Files.Extractor
                     proc.BeginOutputReadLine();
                     proc.BeginErrorReadLine();
 
-                    int exitCode = PosixWait.WaitForExitBlocking(proc.Id);
-                    
-                    try 
-                    {
-                        proc.Refresh();
-                    } 
-                    catch { }
+                    while (!proc.WaitForExit(500)) { }
+                    proc.WaitForExit();
+                    int exitCode = proc.ExitCode;
 
                     if (exitCode != 0)
                         throw new Exception($"Error during File extraction {FileName} (exit code {exitCode}): {string.Join(" ", errorOutput)}");
@@ -100,56 +95,14 @@ namespace Nolvus.Services.Files.Extractor
                 {
                     if (OnProgress != null)
                     {
-                        try 
+                        try
                         {
                             ExtractProgressChanged -= OnProgress;
-                        } 
+                        }
                         catch { }
                     }
                 }
             });
-        }
-
-        private static class PosixWait
-        {
-            [DllImport("libc", SetLastError = true)]
-            private static extern int waitpid(int pid, out int status, int options);
-
-            // Wait until the given PID is reaped. No timeout.
-            public static int WaitForExitBlocking(int pid)
-            {
-                while (true)
-                {
-                    int rc = waitpid(pid, out int status, 0);
-
-                    if (rc == pid)
-                        return DecodeExitCode(status);
-
-                    if (rc == -1)
-                    {
-                        int err = Marshal.GetLastWin32Error();
-
-                        // If errno == ECHILD, someone else already reaped it.
-                        // Treat as success; extraction already finished.
-                        const int ECHILD = 10;
-                        if (err == ECHILD)
-                            return 0;
-
-                        throw new Exception($"waitpid({pid}) failed errno={err}");
-                    }
-                }
-            }
-
-            private static int DecodeExitCode(int status)
-            {
-                // Normal exit: low 7 bits are zero, exit code is high byte.
-                if ((status & 0x7F) == 0)
-                    return (status >> 8) & 0xFF;
-
-                // Signaled: return 128+signal (bash convention)
-                int sig = status & 0x7F;
-                return 128 + sig;
-            }
         }
     }
 }


### PR DESCRIPTION
I'm not sure whether this is optimal as I usually don't do C#, but it did allow the installation to finish cleanly without failing due to `Process terminated. Error while reaping child. errno = 10` very often.
