### PR TITLE
Skip optional stock-game files during patching

### DIFF
--- a/Nolvus.StockGame/Core/StockGameManager.cs
+++ b/Nolvus.StockGame/Core/StockGameManager.cs
@@ -440,6 +440,19 @@ namespace Nolvus.StockGame.Core
 
                     foreach (var Instruction in _Package.Instructions)
                     {
+                        // Optional language files are absent from single-language Steam installs.
+                        if (Instruction.SourceFile != null &&
+                            Instruction.SourceFile.FileSkip &&
+                            !Instruction.SourceFile.Name.Equals(
+                                $"Skyrim - Voices_{_LanguageCode}0.bsa",
+                                StringComparison.OrdinalIgnoreCase))
+                        {
+                            StepProcessed("Skipping optional game file : " + Instruction.DestFile.Name);
+                            ElementProcessed(Counter, Total, StockGameProcessStep.GameFilesPatching, Instruction.DestFile.Name);
+                            Counter++;
+                            continue;
+                        }
+
                         await _Patcher.PatchFile(Instruction, _GameDir, _StockGameDir, _KeepPatches);
 
                         ElementProcessed(Counter, Total, StockGameProcessStep.GameFilesPatching, Instruction.DestFile.Name);

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ chmod +x NolvusDashboard
 
 Or double click `NolvusDashboard`
 
+## Troubleshooting
+
+### Missing Optional Language Files
+
+Steam installs commonly contain only the selected language voice archive. The
+stock-game manifest marks other language archives as optional with `FileSkip`,
+so those files should be skipped during validation, copying, and patching. If
+an installation reports a missing file such as `Skyrim - Voices_fr0.bsa`, make
+sure you are using a build that handles `FileSkip` for patch instructions.
+
 
 ## License
 


### PR DESCRIPTION
## Problem
Single-language Steam installs do not contain optional voice archives such as `Skyrim - Voices_fr0.bsa`. The stock-game manifest marks these files with `FileSkip`, but patch instructions ignored that flag and attempted to patch missing files.

## Change
Skip patch instructions marked `FileSkip`, except for the selected language voice archive. Skipped instructions still update installer progress.

## Documentation
Added a troubleshooting note explaining the missing optional language-file case.

## Verification
- `dotnet build "Nolvus Dashboard Linux.sln" -c Release --no-restore`
- Reproduced the failure before the change and verified the Linux build proceeds past missing optional voice files after the change.