### PR TITLE
Fix invalid-thread errors for free users and prevent soft-locks. Add retry/back/cancel buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# JetBrains Rider
+.idea/

--- a/Nolvus.Browser/BrowserWindow.axaml.cs
+++ b/Nolvus.Browser/BrowserWindow.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using Avalonia.Threading;
 using Nolvus.Browser.Core;
 using Nolvus.Core.Enums;
+using Nolvus.Core.Errors;
 using Nolvus.Core.Events;
 using Nolvus.Core.Interfaces;
 using Nolvus.Core.Services;
@@ -77,6 +78,16 @@ namespace Nolvus.Browser
 
         private Task WaitForClosedAsync() => _closedTcs.Task;
 
+        private async Task<T> AwaitOrClosed<T>(Task<T> task)
+        {
+            var finished = await Task.WhenAny(task, _closedTcs.Task).ConfigureAwait(false);
+
+            if (finished != task)
+                throw new BrowserClosedException();
+
+            return await task.ConfigureAwait(false);
+        }
+
         private void NavigateInternal(string url)
         {
             _cef.Address = url;
@@ -86,11 +97,14 @@ namespace Nolvus.Browser
         {
             _canClose = true;
 
-            if (!string.IsNullOrWhiteSpace(title))
-                TitleBar.Title = title;
-
             _initialUrl = link;
-            Dispatcher.UIThread.Post(() => NavigateInternal(link));
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (!string.IsNullOrWhiteSpace(title))
+                    TitleBar.Title = title;
+
+                NavigateInternal(link);
+            });
         }
 
         public void CloseBrowser()
@@ -111,8 +125,6 @@ namespace Nolvus.Browser
         public async Task NexusSSOAuthentication(string id, string slug)
         {
             _canClose = true;
-
-            TitleBar.Title = "Nexus SSO Authentication";
 
             var startUrl = $"https://www.nexusmods.com/sso?id={id}&application={slug}";
             var tcs = new TaskCompletionSource<object?>(
@@ -137,13 +149,14 @@ namespace Nolvus.Browser
 
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
+                TitleBar.Title = "Nexus SSO Authentication";
                 _cef.LoadEnd += Handler;
                 NavigateInternal(startUrl);
             });
 
             try
             {
-                await tcs.Task.ConfigureAwait(false);
+                await AwaitOrClosed(tcs.Task).ConfigureAwait(false);
             }
             finally
             {
@@ -207,7 +220,7 @@ namespace Nolvus.Browser
                     });
                 }
 
-                await downloadTcs.Task.ConfigureAwait(false);
+                await AwaitOrClosed(downloadTcs.Task).ConfigureAwait(false);
 
                 await Dispatcher.UIThread.InvokeAsync(CloseBrowser);
                 await WaitForClosedAsync().ConfigureAwait(false);
@@ -241,8 +254,6 @@ namespace Nolvus.Browser
         {
             _canClose = true;
 
-            TitleBar.Title = $"Manual download [{modName}]";
-
             var handler = new LinkOnlyDownloadHandler();
 
             var tcs = new TaskCompletionSource<string>(
@@ -258,6 +269,7 @@ namespace Nolvus.Browser
 
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
+                TitleBar.Title = $"Manual download [{modName}]";
                 _cef.DownloadHandler = handler;
                 NavigateInternal(link);
             });
@@ -265,7 +277,7 @@ namespace Nolvus.Browser
             string result;
             try
             {
-                result = await tcs.Task.ConfigureAwait(false);
+                result = await AwaitOrClosed(tcs.Task).ConfigureAwait(false);
             }
             finally
             {

--- a/Nolvus.Browser/BrowserWindow.axaml.cs
+++ b/Nolvus.Browser/BrowserWindow.axaml.cs
@@ -209,7 +209,7 @@ namespace Nolvus.Browser
 
             try
             {
-                await mainLoadTcs.Task.ConfigureAwait(false);
+                await AwaitOrClosed(mainLoadTcs.Task).ConfigureAwait(false);
 
                 if (site == WebSite.EnbDev)
                 {

--- a/Nolvus.Core/Errors/BrowserClosedException.cs
+++ b/Nolvus.Core/Errors/BrowserClosedException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Nolvus.Core.Errors
+{
+    public class BrowserClosedException : Exception
+    {
+        public BrowserClosedException()
+            : base("The browser window was closed before the operation completed.") { }
+
+        public BrowserClosedException(string message) : base(message) { }
+    }
+}

--- a/Nolvus.Core/Interfaces/IDashboard.cs
+++ b/Nolvus.Core/Interfaces/IDashboard.cs
@@ -12,7 +12,7 @@ namespace Nolvus.Core.Interfaces
     {
         Task<T> LoadFrameAsync<T>(FrameParameters Parameters = null) where T : DashboardFrame;
         T LoadFrame<T>(FrameParameters Parameters = null) where T : DashboardFrame;
-        Task Error(string Title, string Message, string Trace = null, bool Retry = false);        
+        Task Error(string Title, string Message, string Trace = null, Func<Task> OnRetry = null, Func<Task> OnBack = null, Func<Task> OnCancel = null);
 
         void ShutDown();
         

--- a/Nolvus.Dashboard/DashboardWindow.axaml.cs
+++ b/Nolvus.Dashboard/DashboardWindow.axaml.cs
@@ -450,7 +450,7 @@ public partial class DashboardWindow : Window, IDashboard
         return Frame;
     }
 
-    public async Task Error(string Title, string Message, string Trace = null, bool Retry = false)
+    public async Task Error(string Title, string Message, string Trace = null, Func<Task> OnRetry = null, Func<Task> OnBack = null, Func<Task> OnCancel = null)
     {
         UnloadLoadingIndicator();
 
@@ -459,7 +459,8 @@ public partial class DashboardWindow : Window, IDashboard
         ServiceSingleton.Logger.Log("Error Form => " + Message);
 
         await LoadFrameAsync<ErrorFrame>(new FrameParameters(FrameParameter.Create("Title", Title), FrameParameter.Create("Message", Message),
-            FrameParameter.Create("Trace", Trace), FrameParameter.Create("Retry", Retry)));
+            FrameParameter.Create("Trace", Trace), FrameParameter.Create("OnRetry", OnRetry),
+            FrameParameter.Create("OnBack", OnBack), FrameParameter.Create("OnCancel", OnCancel)));
 
     }
 

--- a/Nolvus.Dashboard/Frames/ErrorFrame.axaml
+++ b/Nolvus.Dashboard/Frames/ErrorFrame.axaml
@@ -85,7 +85,32 @@
                     HorizontalContentAlignment="Center"
                     VerticalContentAlignment="Center"
                     BorderBrush="#F28F1A"
-                    Foreground="#F28F1A"/>
+                    Foreground="#F28F1A"
+                    IsVisible="False"/>
+
+            <!-- Back button -->
+            <Button x:Name="BtnBack"
+                    Content="Back"
+                    MinWidth="90"
+                    Padding="10,6"
+                    Background="#2E2E2E"
+                    HorizontalContentAlignment="Center"
+                    VerticalContentAlignment="Center"
+                    BorderBrush="White"
+                    Foreground="White"
+                    IsVisible="False"/>
+
+            <!-- Cancel button -->
+            <Button x:Name="BtnCancel"
+                    Content="Cancel"
+                    MinWidth="90"
+                    Padding="10,6"
+                    Background="#2E2E2E"
+                    HorizontalContentAlignment="Center"
+                    VerticalContentAlignment="Center"
+                    BorderBrush="White"
+                    Foreground="White"
+                    IsVisible="False"/>
         </StackPanel>
 
     </Grid>

--- a/Nolvus.Dashboard/Frames/ErrorFrame.axaml.cs
+++ b/Nolvus.Dashboard/Frames/ErrorFrame.axaml.cs
@@ -9,6 +9,9 @@ using System.Net;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Threading.Tasks;
+using Avalonia.Interactivity;
+using Avalonia.Controls;
+using Nolvus.Dashboard.Controls;
 using Nolvus.Core.Interfaces;
 using Nolvus.Core.Frames;
 using Nolvus.Core.Services;
@@ -50,35 +53,64 @@ namespace Nolvus.Dashboard.Frames
             }
         }
 
-        private bool Retry
-        {
-            get
-            {
-                if (Parameters["Retry"] != null)
-                {
-                    return System.Convert.ToBoolean(Parameters["Retry"]);
-                }
+        private Func<Task> OnRetry => Parameters["OnRetry"] as Func<Task>;
 
-                return false;
-            }
-        }
+        private Func<Task> OnBack => Parameters["OnBack"] as Func<Task>;
+
+        private Func<Task> OnCancel => Parameters["OnCancel"] as Func<Task>;
 
         public ErrorFrame(IDashboard Dashboard, FrameParameters Params) :base(Dashboard, Params)
         {
             InitializeComponent();
 
-            //PnlTitle.Background = ;
             LblTitle.Text = Title;
             LblError.Text = Message;
             LblTrace.Text = Trace;
-            BtnRetry.IsVisible = Retry;
+
+            BtnRetry.IsVisible = OnRetry is not null;
+            BtnBack.IsVisible = OnBack is not null;
+            BtnCancel.IsVisible = true;
+
+            BtnRetry.Click += BtnRetry_Click;
+            BtnBack.Click += BtnBack_Click;
+            BtnCancel.Click += BtnCancel_Click;
+
             ServiceSingleton.Dashboard.Title("Nolvus Dashboard - [Error]");
             ServiceSingleton.Dashboard.Info("Error");
         }
 
-        private void BtnRetry_Click(object sender, EventArgs e)
+        private async void BtnRetry_Click(object? sender, RoutedEventArgs e) => await Navigate(OnRetry);
+
+        private async void BtnBack_Click(object? sender, RoutedEventArgs e) => await Navigate(OnBack);
+
+        private async void BtnCancel_Click(object? sender, RoutedEventArgs e)
         {
-            ServiceSingleton.Dashboard.LoadFrame<ResumeFrame>();
+            var owner = TopLevel.GetTopLevel(this) as Window;
+
+            bool? result = await NolvusMessageBox.ShowConfirmation(owner, "Cancel", "Are you sure you want to cancel?");
+
+            if (result is true)
+                await Navigate(OnCancel ?? DefaultCancel);
+        }
+
+        private Task DefaultCancel() => ServiceSingleton.Dashboard.LoadFrameAsync<StartFrame>();
+
+        private async Task Navigate(Func<Task> Action)
+        {
+            if (Action is null)
+                return;
+
+            DisableButtons();
+
+            try
+            {
+                await Action();
+            }
+            catch (Exception ex)
+            {
+                ServiceSingleton.Logger.Log("Error frame navigation failed => " + ex.Message);
+                EnableButtons();
+            }
         }
 
         private void BtnHelp_Click(object sender, EventArgs e)

--- a/Nolvus.Dashboard/Frames/Installer/StockGameFrame.axaml.cs
+++ b/Nolvus.Dashboard/Frames/Installer/StockGameFrame.axaml.cs
@@ -9,6 +9,8 @@ using Nolvus.Core.Enums;
 using Vcc.Nolvus.Api.Installer.Library;
 using Vcc.Nolvus.Api.Installer.Services;
 using Avalonia.Threading;
+using Nolvus.Dashboard.Frames;
+using Nolvus.Dashboard.Frames.Settings;
 
 namespace Nolvus.Dashboard.Frames.Installer
 {
@@ -82,7 +84,10 @@ namespace Nolvus.Dashboard.Frames.Installer
                 }
                 else if (ex is GameFileIntegrityException)
                 {
-                    await ServiceSingleton.Dashboard.Error("Error during game integrity checking", ex.Message);
+                    await ServiceSingleton.Dashboard.Error("Error during game integrity checking", ex.Message,
+                        OnRetry: () => ServiceSingleton.Dashboard.LoadFrameAsync<StockGameFrame>(),
+                        OnBack: () => ServiceSingleton.Dashboard.LoadFrameAsync<GameFrame>(),
+                        OnCancel: CancelInstall);
                 }
                 else if (ex is GameFilePatchingException)
                 {
@@ -199,6 +204,30 @@ namespace Nolvus.Dashboard.Frames.Installer
                     ServiceSingleton.Dashboard.ProgressCompleted();
                 });
             }
+        }
+
+        private async Task CancelInstall()
+        {
+            var Instance = ServiceSingleton.Instances.WorkingInstance;
+
+            if (Instance is not null)
+            {
+                await Task.Run(() =>
+                {
+                    try
+                    {
+                        ServiceSingleton.Files.RemoveDirectory(Instance.InstallDir, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        ServiceSingleton.Logger.Log("Cancel cleanup failed => " + ex.Message);
+                    }
+                });
+
+                ServiceSingleton.Instances.RemoveInstance(Instance);
+            }
+
+            await ServiceSingleton.Dashboard.LoadFrameAsync<StartFrame>();
         }
     }
 }

--- a/Nolvus.Package/Files/ModFile.cs
+++ b/Nolvus.Package/Files/ModFile.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Nolvus.Core.Interfaces;
 using Nolvus.Core.Events;
 using Nolvus.Core.Services;
+using Nolvus.Core.Errors;
 using Nolvus.Core.Utils;
 using Nolvus.Package.Mods;
 using Nolvus.Core.Enums;
@@ -275,7 +276,20 @@ namespace Nolvus.Package.Files
                     }
                     if (RequireManualDownload)
                     {
-                        await Browser().AwaitUserDownload(Link, FileName, OnProgress);
+                        var browserTries = 0;
+                        while (true)
+                        {
+                            try
+                            {
+                                await Browser().AwaitUserDownload(Link, FileName, OnProgress);
+                                break;
+                            }
+                            catch (BrowserClosedException) when (browserTries < RetryCount)
+                            {
+                                browserTries++;
+                                ServiceSingleton.Logger.Log($"Download window closed before completing, reopening ({browserTries}/{RetryCount}) for {FileName}");
+                            }
+                        }
                     }
                     else
                     {

--- a/Nolvus.Package/Mods/InstallableElement.cs
+++ b/Nolvus.Package/Mods/InstallableElement.cs
@@ -12,6 +12,7 @@ using Nolvus.Core.Enums;
 using Nolvus.Core.Events;
 using Nolvus.Core.Services;
 using Nolvus.Core.Interfaces;
+using Nolvus.Core.Errors;
 using Nolvus.Package.Files;
 using Nolvus.NexusApi;
 
@@ -307,8 +308,22 @@ namespace Nolvus.Package.Mods
                 try
                 {
                     ServiceSingleton.Logger.Log($"Awaiting manual user download link for file {file.FileName}");
-                    var browser = Browser();
-                    file.DownloadLink = await browser.GetNexusManualDownloadLink(Name, file.DownloadLink, file.NexusId).ConfigureAwait(false);
+
+                    var browserTries = 0;
+                    while (true)
+                    {
+                        try
+                        {
+                            var browser = Browser();
+                            file.DownloadLink = await browser.GetNexusManualDownloadLink(Name, file.DownloadLink, file.NexusId).ConfigureAwait(false);
+                            break;
+                        }
+                        catch (BrowserClosedException) when (browserTries < ServiceSingleton.Settings.RetryCount)
+                        {
+                            browserTries++;
+                            ServiceSingleton.Logger.Log($"Manual download window closed before completing, reopening ({browserTries}/{ServiceSingleton.Settings.RetryCount}) for file {file.FileName}");
+                        }
+                    }
                 }
                 finally
                 {


### PR DESCRIPTION
Fixes the CEF deadlocks and "call from invalid thread" errors free Nexus accounts hit during install, and adds Retry/Back/Cancel actions to the error frame.